### PR TITLE
Reverse sequence

### DIFF
--- a/Sources/Nucleotide/Sequence/Analyze/Standard.swift
+++ b/Sources/Nucleotide/Sequence/Analyze/Standard.swift
@@ -51,7 +51,7 @@ public extension BaseSequence {
     func complementaryStrand() -> BaseSequence<T> {
         return BaseSequence<T>(sequence: self.sequence.map({ n in
             bitRotateLeft(n, n: 4)
-        }))
+        }).reversed())
     }
     
     /// 相補的な配列を算出します.
@@ -60,7 +60,12 @@ public extension BaseSequence {
     func complementaryStrand<U: BaseType>(typeOf type: U.Type) -> BaseSequence<U> {
         return BaseSequence<U>(sequence: self.sequence.map({ n in
             bitRotateLeft(n, n: 4)
-        }))
+        }).reversed())
+    }
+    
+    /// 逆向き配列を出力します.
+    func reversed() -> BaseSequence<T> {
+        return BaseSequence<T>(sequence: self.sequence.reversed())
     }
     
 }

--- a/Tests/NucleotideTests/APITests/AnalyzeTests.swift
+++ b/Tests/NucleotideTests/APITests/AnalyzeTests.swift
@@ -62,8 +62,8 @@ final class AnalyzerMeasureTests: XCTestCase {
     func testComplementaryStrand() throws {
         var result: BaseSequence<DNA>?
         let target = BaseSequence<DNA>.init(
-            stringLiteral: String(repeating: "T",
-                                  count: self.seqLength/2) + String(repeating: "C",
+            stringLiteral: String(repeating: "C",
+                                  count: self.seqLength/2) + String(repeating: "T",
                                                                     count: self.seqLength/2))
         guard let seq = self.seq else {
             return
@@ -108,8 +108,21 @@ final class AnalyzeTests: XCTestCase {
 //    相補的な配列を算出するテスト.
     func testComplementaryStrand() throws {
         let dna: BaseSequence<DNA> = "ATGCATGCN"
-        XCTAssertEqual(dna.complementaryStrand().description, "DNA: TACGTACGN")
-        XCTAssertEqual(dna.complementaryStrand(typeOf: RNA.self).description, "RNA: UACGUACGN")
+        XCTAssertEqual(
+            dna.complementaryStrand()
+                .description, "DNA: NGCATGCAT")
+        XCTAssertEqual(
+            dna.complementaryStrand(typeOf: RNA.self)
+                .description, "RNA: NGCAUGCAU")
+        
+    }
+    
+//    逆向き配列を算出するテスト.
+    func testfReverseStrand() throws {
+        let dna: BaseSequence<DNA> = "ATGCATGCN"
+        XCTAssertEqual(
+            dna.reversed()
+                .description, "DNA: NCGTACGTA")
         
     }
     


### PR DESCRIPTION
既存の塩基配列を逆向きにするメソッドを追加した. 相補鎖の生成を逆向きになるように変更した.